### PR TITLE
parentStatusesで落ちるのを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,8 @@ handler.on('status', event => {
 					return;
 				}
 				const parentStatuses = JSON.parse(body);
-				const parentState = parentStatuses[0].state;
-				const stillFailed = parentState == 'failure' || parentState == 'error';
+				const parentState = parentStatuses[0]?.state;
+				const stillFailed = parentState === 'failure' || parentState === 'error';
 				if (stillFailed) {
 					post(`⚠️**BUILD STILL FAILED**⚠️: ?[${commit.commit.message}](${commit.html_url})`);
 				} else {


### PR DESCRIPTION
たぶん、pull request直後の最初のチェック (とかそのリポジトリで最初のチェック) がコケるとエラーで落ちてしまうのを修正。
https://misskey.dev/notes/8hokvjgc4u