### PR TITLE
Misskey側でメンションとハッシュタグ扱いにしないように

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ const post = async (text: string, home = true) => {
 	request.post(config.instance + '/api/notes/create', {
 		json: {
 			i: config.i,
-			text, visibility: home ? 'home' : 'public'
+			text,
+			visibility: home ? 'home' : 'public',
+			noExtractMentions: true,
+			noExtractHashtags: true
 		}
 	});
 };


### PR DESCRIPTION
GitHub側で `@User`, `#Number` といったシーケンスがあった場合でも、
Misskey側で メンションやハッシュタグとして扱わないようにします。

MFMやクライアントの仕様上リンク表示にはなりますが、
メンションとして通知が飛んだりハッシュタグとしてDBに登録されたりはしなくなります。

Misskey APIオプション (v10.66.2 で実装済み)
https://github.com/misskey-dev/misskey/pull/3721

Related Issues
https://github.com/misskey-dev/misskey/issues/8763