### PR TITLE
feat: プルリクエストについたコメントの通知対応

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,7 @@
+{
+	"instance": "https://example.com/",
+	"i": "",
+	"hookSecret": "",
+	"port": 8080,
+	"proxy": null
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import * as Koa from 'koa';
 import * as Router from 'koa-router';
 import * as bodyParser from 'koa-bodyparser';
 import * as request from 'request';
-const crypto = require('crypto');
-const config = require('../config.json');
+import crypto = require('crypto');
+import config = require('../config.json');
 
 const handler = new EventEmitter();
 
@@ -157,6 +157,17 @@ handler.on('pull_request', event => {
 				? `💯 Pull Request Merged!: "${pr.title}"\n${pr.html_url}`
 				: `🚫 Pull Request Closed: "${pr.title}"\n${pr.html_url}`;
 			break;
+		default: return;
+	}
+	post(text);
+});
+
+handler.on('pull_request_review_comment', event => {
+	const pr = event.pull_request_review_comment;
+	const action = event.action;
+	let text: string;
+	switch (action) {
+		case 'created': text = `💬 Commented on "${pr.title}": ${pr.user.login} "<plain>${pr.body}</plain>"\n${pr.html_url}`; break;
 		default: return;
 	}
 	post(text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,11 +164,24 @@ handler.on('pull_request', event => {
 });
 
 handler.on('pull_request_review_comment', event => {
-	const pr = event.pull_request_review_comment;
+	const pr = event.pull_request;
+	const comment = event.comment;
 	const action = event.action;
 	let text: string;
 	switch (action) {
-		case 'created': text = `💬 Commented on "${pr.title}": ${pr.user.login} "<plain>${pr.body}</plain>"\n${pr.html_url}`; break;
+		case 'created': text = `💬 Commented on "${pr.title}": ${comment.user.login} "<plain>${comment.body}</plain>"\n${comment.html_url}`; break;
+		default: return;
+	}
+	post(text);
+});
+
+handler.on('pull_request_review', event => {
+	const pr = event.pull_request;
+	const review = event.review;
+	const action = event.action;
+	let text: string;
+	switch (action) {
+		case 'submitted': text = `👀 Review submitted: "${pr.title}": ${review.user.login} "<plain>${review.body}</plain>"\n${review.html_url}`; break;
 		default: return;
 	}
 	post(text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import * as Router from 'koa-router';
 import * as bodyParser from 'koa-bodyparser';
 import * as request from 'request';
 import crypto = require('crypto');
-import config = require('../config.json');
+
+const config = require('../config.json');
 
 const handler = new EventEmitter();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"experimentalDecorators": true,
 		"sourceMap": false,
+		"resolveJsonModule": true,
 		"target": "es6",
 		"module": "commonjs",
 		"removeComments": false,


### PR DESCRIPTION
#8 の対応です。
プルリクのコメントもbotから流すようになります。

送信するwebhookを個別で設定している場合、以下の設定が必要です。
- Pull request reviews
レビュー時のコメントを検知するのに必要（差分にコメント→Review changesボタンを押したときに書き込むやつ）
- Pull request review comments
差分についたコメントに返信した時のコメントを検知するのに必要

こんな感じ
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/b9614b4f-bbc2-40eb-a4f4-afd41385a374)
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/c04aceae-4998-4dbb-b9f4-7ada59fa5189)
