### PR TITLE
feat: discussionsの通知に対応

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,4 +162,43 @@ handler.on('pull_request', event => {
 	post(text);
 });
 
+handler.on('discussion', event => {
+	const discussion = event.discussion;
+	const action = event.action;
+	let title: string;
+	let url: string;
+	switch (action) {
+		case 'created':
+			title = `💭 Discussion opened`;
+			url = discussion.html_url;
+			break;
+		case 'closed':
+			title = `💮 Discussion closed`;
+			url = discussion.html_url;
+			break;
+		case 'reopened':
+			title = `🔥 Discussion reopened`;
+			url = discussion.html_url;
+			break;
+		case 'answered':
+			title = `✅ Discussion marked awnser`;
+			url = discussion.answer_html_url;
+			break;
+		default: return;
+	}
+	post(`${title}: #${discussion.number} "${discussion.title}"\n${url}`);
+});
+
+handler.on('discussion_comment', event => {
+	const discussion = event.discussion;
+	const comment = event.comment;
+	const action = event.action;
+	let text: string;
+	switch (action) {
+		case 'created': text = `💬 Commented on "${discussion.title}": ${comment.user.login} "<plain>${comment.body}</plain>"\n${comment.html_url}`; break;
+		default: return;
+	}
+	post(text);
+});
+
 console.log("🚀 Ready! 🚀")


### PR DESCRIPTION
#9 の対応です。
Discussionsの通知もbotから流すようにします。

送信するwebhookを個別で設定している場合、以下の設定が必要です。

- Discussions 
Discussionsが作成された時、閉じられた時、再オープンされた時、回答がマークされた時の通知に使用
- Discussion comments 
Discussionsについたコメントを検知するのに使用

◎Ideasなど、回答をマークする機能が無いもの
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/bc9643b9-4449-4b44-b4c5-e76120c76b14)
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/bc3041c9-257f-4d3d-9193-4ee58640db37)
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/b1bedef1-79b2-4f8a-a41e-48c555b70566)

◎QAなど、回答をマークする機能があるもの
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/496d5fc8-1e82-4d59-a6be-3a7dd676fc16)
![image](https://github.com/syuilo/misskey-github-notifier/assets/46447427/dd8d08e4-34b9-41ee-a71a-7b85291a5380)
