### PR TITLE
fix: pull_request_reviewのbodyが空の時は通知しないようにする（ほか微調整）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,8 @@ handler.on('pull_request_review_comment', event => {
 handler.on('pull_request_review', event => {
 	const pr = event.pull_request;
 	const review = event.review;
+	if (review.body === null) return;
+
 	const action = event.action;
 	let text: string;
 	switch (action) {
@@ -206,7 +208,7 @@ handler.on('discussion', event => {
 			url = discussion.html_url;
 			break;
 		case 'answered':
-			title = `✅ Discussion marked awnser`;
+			title = `✅ Discussion marked answer`;
 			url = discussion.answer_html_url;
 			break;
 		default: return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ handler.on('pull_request_review_comment', event => {
 	const action = event.action;
 	let text: string;
 	switch (action) {
-		case 'created': text = `💬 Commented on "${pr.title}": ${comment.user.login} "<plain>${comment.body}</plain>"\n${comment.html_url}`; break;
+		case 'created': text = `💬 Review commented on "${pr.title}": ${comment.user.login} "<plain>${comment.body}</plain>"\n${comment.html_url}`; break;
 		default: return;
 	}
 	post(text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,7 @@ handler.on('pull_request_review_comment', event => {
 handler.on('pull_request_review', event => {
 	const pr = event.pull_request;
 	const review = event.review;
-	if (review.body === null) return;
+	if (review.body === undefined || review.body === null || review.body.length <= 0) return;
 
 	const action = event.action;
 	let text: string;


### PR DESCRIPTION
以下のように、レビュー送信時にbodyが空だとnullという文字だけが出てしまうのを防ぎます
https://p1.a9z.dev/notes/9p7tizw71v
https://p1.a9z.dev/notes/9p7tdjat1n
https://p1.a9z.dev/notes/9p6xefq5rn

ほか、以下の対応もしています
- typoしていたのを修正
- レビューコメントと通常コメントの区別がつきにくかったのでメッセージを一部変更