### PR TITLE
fix: targetをesnextにする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"strictNullChecks": true,
 		"sourceMap": false,
 		"resolveJsonModule": true,
-		"target": "es6",
+		"target": "esnext",
 		"module": "commonjs",
 		"removeComments": false,
 		"noLib": false,


### PR DESCRIPTION
es6になっててビルドに失敗するので（依存パッケージの追加更新によるものだと思う）